### PR TITLE
fix: SLR scraper improvements and Scrapers page bug fixes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,6 @@ type ObjectConfig struct {
 		SceneCardScaleToFit  bool   `default:"true" json:"sceneCardScaleToFit"`
 		ActorCardAspectRatio string `default:"1:1" json:"actorCardAspectRatio"`
 		ActorCardScaleToFit  bool   `default:"true" json:"actorCardScaleToFit"`
-		ShowAllScrapers      bool   `default:"false" json:"showAllScrapers"`
 	} `json:"web"`
 	Advanced struct {
 		ShowInternalSceneId          bool      `default:"false" json:"showInternalSceneId"`

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -24,7 +24,6 @@ const state = {
     sceneCardScaleToFit: true,
     actorCardAspectRatio: "1:1",
     actorCardScaleToFit: true,
-    showAllScrapers: false,
     updateCheck: true
   }
 }
@@ -58,7 +57,6 @@ const actions = {
         state.web.sceneCardScaleToFit = data.config.web.sceneCardScaleToFit
         state.web.actorCardAspectRatio = data.config.web.actorCardAspectRatio
         state.web.actorCardScaleToFit = data.config.web.actorCardScaleToFit
-        state.web.showAllScrapers = data.config.web.showAllScrapers
         state.loading = false
       })
   },
@@ -88,7 +86,6 @@ const actions = {
         state.web.sceneCardScaleToFit = data.sceneCardScaleToFit
         state.web.actorCardAspectRatio = data.actorCardAspectRatio
         state.web.actorCardScaleToFit = data.actorCardScaleToFit
-        state.web.showAllScrapers = data.showAllScrapers
         state.loading = false
       })
   }

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -18,8 +18,8 @@
             </div>
           </b-dropdown-item>
         </b-dropdown>
-        <a class="button" :class="[$store.state.optionsWeb.web.showAllScrapers ? 'is-info' : '']" v-on:click="toggleEnabledFilter">
-          {{$store.state.optionsWeb.web.showAllScrapers ? $t('Show all scrapers') : $t('Show enabled only')}}
+        <a class="button" :class="[showAllScrapers ? '' : 'is-info']" v-on:click="toggleEnabledFilter">
+          {{showAllScrapers ? $t('Show enabled only') : $t('Show all scrapers')}}
         </a>
         <a class="button is-primary" v-on:click="taskScrape('_enabled')">{{$t('Run selected scrapers')}}</a>
       </div>
@@ -178,6 +178,7 @@ export default {
       currentScraper: '',
       scraperwarning: '',
       scraperwarning2: '',
+      showAllScrapers: true,
     }
   },
   mounted () {
@@ -393,8 +394,7 @@ export default {
       })
     },
     toggleEnabledFilter() {
-      this.$store.state.optionsWeb.web.showAllScrapers = !this.$store.state.optionsWeb.web.showAllScrapers
-      this.$store.dispatch('optionsWeb/save')
+      this.showAllScrapers = !this.showAllScrapers
     },
     saveAdvancedSettings() {
       this.$store.dispatch('optionsAdvanced/save')
@@ -425,7 +425,7 @@ export default {
       }
 
       // Filter by enabled status if the filter is active
-      if (this.$store.state.optionsWeb.web.showAllScrapers) {
+      if (!this.showAllScrapers) {
         items = items.filter(item => item.is_enabled === true);
       }
 


### PR DESCRIPTION
- Fix Scrapers page not showing scrapers on slow devices due to race condition with async store loading. Changed showAllScrapers to local component state with default true instead of persisted store state.

- Fix Auto-limit scraping being enabled even when scrape failed (e.g., "Studio code not found" errors). Now only enables after successful scrape.

- Fix SLR URL generation producing invalid double-dash URLs. Now uses the `label` field from SLR API directly instead of regenerating URL slugs from titles, preserving legitimate double-dash URLs while avoiding invalid ones.

- Disable limit scraping when user selects "Force update scenes" to allow full re-scrape, matching the behavior of "Delete scraped scenes".